### PR TITLE
Amend :length validation inference to work on any derivation of Text or String.

### DIFF
--- a/lib/dm-validations/auto_validate.rb
+++ b/lib/dm-validations/auto_validate.rb
@@ -130,7 +130,7 @@ module DataMapper
       end
 
       def infer_length_validation_for(property, options)
-        return unless [ DataMapper::Property::String, DataMapper::Property::Text ].include?(property.class)
+        return unless [ DataMapper::Property::String, DataMapper::Property::Text ].any? { |klass| property.kind_of?(klass) }
 
         case length = property.options.fetch(:length, DataMapper::Property::String::DEFAULT_LENGTH)
           when Range then options[:within]  = length


### PR DESCRIPTION
Previously, inferred validation for :length only worked on Text or String property classes only.  But if one of these types is subclassed, the common expectation is more likely to be that their (auto) validations are inherited as well as their behaviours.

Example of why I consider this better: http://gist.github.com/595941

In this case, the :format auto-validation kicks in as expected, but the :length validation does not.  However since I'm deriving from String, I argue that I'm explicitly stating I should be operating on a String, thus I should expect that any String auto-validations would apply.
