### PR TITLE
Association validation

### DIFF
--- a/lib/dm-validations.rb
+++ b/lib/dm-validations.rb
@@ -260,9 +260,9 @@ module DataMapper
           end
 
           if cardinality == 1 || (cardinality.is_a?(Range) && cardinality.max == 1)
-            add_validation[lambda {|val| val && !val.valid? }]
+            add_validation[lambda {|val| val && val.dirty? && !val.valid? }]
           else
-            add_validation[lambda {|val| !val.map(&:valid?).all? }]
+            add_validation[lambda {|val| val.loaded? && !val.map(&:valid?).all? }]
           end
         end
       end

--- a/spec/fixtures/company.rb
+++ b/spec/fixtures/company.rb
@@ -75,7 +75,8 @@ module DataMapper
 
         property :id, Serial
         belongs_to :product_company
-        property :description, Text, :required => true
+        property :description, Text, :required => false # Allow NULL values, enforce validation in the app
+        validates_presence_of :description
       end
 
       class Product

--- a/spec/integration/datamapper_models/association_validation_spec.rb
+++ b/spec/integration/datamapper_models/association_validation_spec.rb
@@ -27,7 +27,36 @@ end
 
 describe 'DataMapper::Validations::Fixtures::ProductCompany' do
   before :all do
-    @model = DataMapper::Validations::Fixtures::ProductCompany.new(:title => "Apple", :flagship_product => "Macintosh")
+    @model = DataMapper::Validations::Fixtures::ProductCompany.create(:title => "Apple", :flagship_product => "Macintosh")
+  end
+
+  describe 'with no products loaded' do
+    it 'does not load or validate it' do
+      @model.reload
+      @model.valid?
+      @model.products.should_not be_loaded
+    end
+  end
+
+  describe 'with no profile loaded' do
+    it 'does not load or validate it' do
+      pending "Unsure how to test this"
+      @model.reload
+      @model.valid?
+      @model.profile.should_not be_loaded
+    end
+  end
+
+  describe 'with not dirty profile' do
+    before :all do
+      # Force an invalid, yet clean model. This should not happen in real
+      # code, but gives us an easy way to check whether the validations
+      # are getting run on the profile.
+      profile = DataMapper::Validations::Fixtures::Profile.create!(:product_company => @model)
+      @model.reload
+    end
+
+    it_should_behave_like "valid model"
   end
 
   describe 'with invalid products' do


### PR DESCRIPTION
Currently, there is a confusing behaviour with validations:

```
require 'dm-validations'

class User
  include DataMapper::Resource

  has n, :posts
end

class Post
  belongs_to :user

  property :id, Serial
  property :title, String, :required => true
end

user = User.new(:posts => [{:title => ''}])
user.valid? # => true
user.save   # => false
```

This in particular crops up as an issue when using dm-nested-attributes. These commits add auto-validation to associations to make #valid? return false in the above example. There are also safe-guards to prevent "known good" children from being validated, without which saving a parent model could trigger a massive chain of child validations. "Known good" is defined as either not loaded or clean.

There is still a pending issue that has 1 associations are always loaded, but validations are not run on them if they are clean (which they will be if they were just loaded). This isn't a deal breaker IMO, you just possibly get one redundant query when running validations. If anyone knows how to test if a has 1 is loaded though this can be fixed.

Anyone for see any issues with this? We have been using a monkey-patched version of this code on our app for a few months now (the bug caused much consternation before we identified it).
