### PR TITLE
Minor Documentation Correction

### DIFF
--- a/lib/dm-validations/validators/numeric_validator.rb
+++ b/lib/dm-validations/validators/numeric_validator.rb
@@ -152,10 +152,10 @@ module DataMapper
       #   Required scale of a value.
       #
       # @option [Numeric] :gte
-      #   'Greater than or greater' requirement.
+      #   'Greater than or equal to' requirement.
       #
       # @option [Numeric] :lte
-      #   'Less than or greater' requirement.
+      #   'Less than or equal to' requirement.
       #
       # @option [Numeric] :lt
       #   'Less than' requirement.


### PR DESCRIPTION
The documentation said "greater than or greater" and "less than or greater" instead of "\* than or equal".  Quick fix.
