### PR TITLE
Improving the documentation for validates_within

### DIFF
--- a/lib/dm-validations/validators/within_validator.rb
+++ b/lib/dm-validations/validators/within_validator.rb
@@ -40,8 +40,32 @@ module DataMapper
     end # class WithinValidator
 
     module ValidatesWithin
-      # Validate that value of a field if within a range/set
+      ##
+      # Validates that the value of a field is within a range/set.
       #
+      # This validation is defined by passing a field along with a :set
+      # parameter. The :set can be a Range or any object which responds
+      # to the #include? method (an array, for example).
+      #
+      # @example Usage
+      #   require 'dm-validations'
+      #
+      #   class Review
+      #     include DataMapper::Resource
+      #
+      #     STATES = ['new', 'in_progress', 'published', 'archived']
+      #
+      #     property :title, String
+      #     property :body, String
+      #     property :review_state, String
+      #     property :rating, Integer
+      #
+      #     validates_within :review_state, :set => STATES
+      #     validates_within :rating,       :set => 1..5
+      #
+      #     # a call to valid? will return false unless
+      #     # the two properties conform to their sets
+      #   end
       def validates_within(*fields)
         validators.add(WithinValidator, *fields)
       end


### PR DESCRIPTION
It wasn't documented anywhere explicitly how to use validates_within.  The YARD doc was correct, but vague. I used the YARD doc for required_field_validator as a template and modified it to document validates_within usage.
