### PR TITLE
Fix validates_format_of with URI type

### DIFF
--- a/lib/dm-validations/validators/format_validator.rb
+++ b/lib/dm-validations/validators/format_validator.rb
@@ -59,10 +59,10 @@ module DataMapper
                     else
                       validation
                     end
-
+        
         case validator
           when Proc   then validator.call(value)
-          when Regexp then (value.kind_of?(Numeric) ? value.to_s : value) =~ validator
+          when Regexp then (( DataMapper::Ext.blank?(value) || value.kind_of?(String)) ? value : value.to_s) =~ validator
           else
             raise(UnknownValidationFormat, "Can't determine how to validate #{target.class}##{field_name} with #{validator.inspect}")
         end

--- a/spec/fixtures/bill_of_landing.rb
+++ b/spec/fixtures/bill_of_landing.rb
@@ -20,6 +20,7 @@ module DataMapper
         property :email,    String, :auto_validation => false
         property :username, String, :auto_validation => false
         property :url,      String, :auto_validation => false
+        property :bank_url, URI,    :auto_validation => false
         property :code,     String, :auto_validation => false, :default => "123456"
 
         #
@@ -36,6 +37,10 @@ module DataMapper
 
         validates_format_of :username, :with => /[a-z]/, :message => 'Username must have at least one letter', :allow_nil => true
         validates_format_of :code,     :with => /\d{5,6}/, :message => 'Code format is invalid'
+      end
+      
+      class SurrenderBillOfLading < BillOfLading
+        validates_format_of :bank_url, :as => :url, :allow_nil => false, :allow_blank => false
       end
     end # Fixtures
   end # Validations

--- a/spec/integration/format_validator/url_format_validator_spec.rb
+++ b/spec/integration/format_validator/url_format_validator_spec.rb
@@ -4,13 +4,15 @@ require 'integration/format_validator/spec_helper'
 describe 'DataMapper::Validations::Fixtures::BillOfLading' do
   before :all do
     DataMapper::Validations::Fixtures::BillOfLading.auto_migrate!
+    # ForkOperation.auto_migrate!
+    # DataMapper::Validations::Fixtures::SurrenderBillOfLading.auto_migrate!
   end
 
   def valid_attributes
     { :id => 1, :doc_no => 'A1234', :email => 'user@example.com', :url => 'http://example.com' }
   end
 
-  [ 'http:// example.com', 'ftp://example.com', 'http://.com', 'http://', 'test', '...',
+  invalid_uris = [ 'http:// example.com', 'ftp://example.com', 'http://.com', 'http://', 'test', '...',
     # these are valid URIs from RFC perspective,
     # but too often not the case for web apps
     #
@@ -18,7 +20,9 @@ describe 'DataMapper::Validations::Fixtures::BillOfLading' do
     # RFC compliant so it can be used, for instance,
     # for internal apps that may refer to local domains
     # like http://backend:8080
-    "http://localhost:4000", "http://localhost" ].each do |uri|
+    "http://localhost:4000", "http://localhost" ]
+    
+  invalid_uris.each do |uri|
     describe "with URL of #{uri}" do
       before :all do
         @model = DataMapper::Validations::Fixtures::BillOfLading.new(valid_attributes.merge(:url => uri))
@@ -29,6 +33,22 @@ describe 'DataMapper::Validations::Fixtures::BillOfLading' do
       it "has a meaningful error message" do
         @model.errors.on(:url).should == [ 'Url has an invalid format' ]
       end
+    end
+  end
+  
+  # http:// throws an exception in Addressable::URI, so it wouldn't make it to the validation part anyway :)
+  (invalid_uris - ['http://']).each do |uri|
+    describe "with dm-type URI of #{uri}" do
+      before(:all) do
+        @model = DataMapper::Validations::Fixtures::SurrenderBillOfLading.new(valid_attributes.merge(:bank_url => uri))
+      end
+
+      it_should_behave_like "invalid model"
+      
+      it "has a meaningful error message" do
+        @model.errors.on(:bank_url).should == [ 'Bank url has an invalid format' ]
+      end
+      
     end
   end
 
@@ -61,6 +81,14 @@ describe 'DataMapper::Validations::Fixtures::BillOfLading' do
        @model = DataMapper::Validations::Fixtures::BillOfLading.new(valid_attributes.merge(:url => uri))
      end
 
+     it_should_behave_like "valid model"
+   end
+   
+   describe "with dm-type URI of #{uri}" do
+     before(:all) do
+       @model = DataMapper::Validations::Fixtures::SurrenderBillOfLading.new(valid_attributes.merge(:bank_url => uri))
+     end
+     
      it_should_behave_like "valid model"
    end
  end


### PR DESCRIPTION
`validates_format_of :something, :as => :uri` doesn't validate correctly if `:something` is DM::Type::URI
