### PR TITLE
Do not optimize away checking non-dirty attributes

### DIFF
--- a/lib/dm-validations.rb
+++ b/lib/dm-validations.rb
@@ -48,7 +48,7 @@ module DataMapper
 
     # @api private
     def save_self(*)
-      if dirty_self? && Validations::Context.any? && !valid?(model.validators.current_context)
+      if Validations::Context.any? && !valid?(model.validators.current_context)
         false
       else
         super

--- a/lib/dm-validations/contextual_validators.rb
+++ b/lib/dm-validations/contextual_validators.rb
@@ -177,7 +177,7 @@ module DataMapper
 
       # Execute all validators in the named context against the target.
       # Load together any properties that are designated lazy but are not
-      # yet loaded. Optionally only validate dirty properties.
+      # yet loaded.
       #
       # @param [Symbol] named_context
       #   the context we are validating against
@@ -191,52 +191,14 @@ module DataMapper
         available_validators  = context(named_context)
         executable_validators = available_validators.select { |v| v.execute?(target) }
 
-        # By default we start the list with the full set of executable
-        # validators.
-        #
         # In the case of a new Resource or regular ruby class instance,
         # everything needs to be validated completely, and no eager-loading
         # logic should apply.
         #
-        # @see #validators_for_resource
-        validators = 
-          if target.kind_of?(DataMapper::Resource) && !target.new?
-            validators_for_resource(target, executable_validators)
-          else
-            executable_validators
-          end
-
-        validators.map { |validator| validator.call(target) }.all?
-      end
-
-      # In the case of a DM::Resource that isn't new, we optimize:
-      #
-      #   1. Eager-load all lazy, not-yet-loaded properties that need
-      #      validation, all at once.
-      #
-      #   2. Limit run validators to
-      #      - those applied to dirty attributes only,
-      #      - those that should always run (presence/absence)
-      #      - those that don't reference any real properties (attribute-less
-      #        block validators, validations in virtual attributes)
-      def validators_for_resource(resource, all_validators)
-        attrs       = resource.attributes
-        dirty_attrs = Hash[resource.dirty_attributes.map { |p, value| [p.name, value] }]
-        validators  = all_validators.select { |v|
-          !attrs.include?(v.field_name) || dirty_attrs.include?(v.field_name)
-        }
-
-        load_validated_properties(resource, validators)
-
-        # Finally include any validators that should always run or don't
-        # reference any real properties (field-less block vaildators).
-        validators |= all_validators.select do |v|
-          v.kind_of?(MethodValidator) ||
-          v.kind_of?(PresenceValidator) ||
-          v.kind_of?(AbsenceValidator)
+        if target.kind_of?(DataMapper::Resource) && !target.new?
+          load_validated_properties(target, executable_validators)
         end
-
-        validators
+        executable_validators.map { |validator| validator.call(target) }.all?
       end
 
       # Load all lazy, not-yet-loaded properties that need validation,

--- a/spec/fixtures/llama_spaceship.rb
+++ b/spec/fixtures/llama_spaceship.rb
@@ -1,0 +1,15 @@
+module DataMapper
+  module Validations
+    module Fixtures
+      class LlamaSpaceship
+        include DataMapper::Resource
+
+        property :id, Serial
+        property :type, String
+        property :color, String
+
+        validates_format_of :color, :with => /^red|black$/, :if => Proc.new { |spaceship| spaceship.type == "standard" }
+      end
+    end
+  end
+end

--- a/spec/integration/dirty_attributes/dirty_attributes_spec.rb
+++ b/spec/integration/dirty_attributes/dirty_attributes_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'DataMapper::Validations::Fixtures::LlamaSpaceship' do
+  before :all do
+    DataMapper::Validations::Fixtures::LlamaSpaceship.auto_migrate!
+  end
+
+  it "validates even non dirty attributes" do
+    spaceship = DataMapper::Validations::Fixtures::LlamaSpaceship.create(:type => "custom", :color => "pink")
+    spaceship.type = "standard"
+    spaceship.should_not be_valid
+  end
+end

--- a/spec/public/resource_spec.rb
+++ b/spec/public/resource_spec.rb
@@ -84,8 +84,8 @@ describe 'DataMapper::Resource' do
         @resource.save
       end
 
-      it 'should not call valid?' do
-        @resource.valid_hook_call_count.should be_nil
+      it 'should call valid?' do
+        @resource.valid_hook_call_count.should == 1
       end
     end
 


### PR DESCRIPTION
There are a lot of situations where this is a bad
move and can lead to invalid data in the database.
The attached testcase is a simple example of this
problem, where a change to another field
invalidates the resource. DM will now happily save
this resource, even though it is quite clearly
invalid.

We also removed the check where valid? isn't
called at all if the model isn't dirty. It's not
safe to assume that the model is valid just
because there are no dirty attributes, the
validations of the model class may have changed
since the model was added to the DB. With the
current architecture there is no way of even
checking _if_ such invalid models exist.
