### PR TITLE
Update ValidationErrors#full_messages to support dm-validations-ext.

### DIFF
--- a/lib/dm-validations/validation_errors.rb
+++ b/lib/dm-validations/validation_errors.rb
@@ -84,8 +84,9 @@ module DataMapper
 
       # Collect all errors into a single list.
       def full_messages
-        errors.inject([]) do |list, pair|
-          list += pair.last
+        errors.inject([]) do |list, (attribute, errors)|
+          more = errors.respond_to?(:full_messages) ? errors.full_messages : errors
+          list += more
         end
       end
 


### PR DESCRIPTION
When using solnic/dm-validations-ext without this patch, `#full_messages` blows up attempting to concatenate a ValidationErrors instance with an array, which isn't supported. /cc @solnic
