### PR TITLE
Fix options passed to BlockValidator

### DIFF
--- a/lib/dm-validations/validators/block_validator.rb
+++ b/lib/dm-validations/validators/block_validator.rb
@@ -50,7 +50,7 @@ module DataMapper
         method_name = "__validates_with_block_#{@__validates_with_block_count}".to_sym
         define_method(method_name, &block)
 
-        options = fields.last.is_a?(Hash) ? fields.last.pop.dup : {}
+        options = fields.last.is_a?(Hash) ? fields.pop.dup : {}
         options[:method] = method_name
         fields = [method_name] if fields.empty?
 

--- a/spec/fixtures/g3_concert.rb
+++ b/spec/fixtures/g3_concert.rb
@@ -14,13 +14,13 @@ module DataMapper
         # Attributes
         #
 
-        attr_accessor :year, :participants, :city
+        attr_accessor :year, :participants, :city, :planned
 
         #
         # Validations
         #
 
-        validates_with_block :participants do
+        validates_with_block :participants, :unless => :planned do
           if self.class.known_performances.any? { |perf| perf == self }
             true
           else

--- a/spec/integration/block_validator/block_validator_spec.rb
+++ b/spec/integration/block_validator/block_validator_spec.rb
@@ -29,4 +29,13 @@ describe 'DataMapper::Validations::Fixtures::G3Concert' do
 
     it_should_behave_like "valid model"
   end
+
+  describe "planned concert for non-existing year/participants/city combinations" do
+    before :all do
+      @model.planned = true
+      @model.year         = 2021
+    end
+
+    it_should_behave_like "valid model"
+  end
 end


### PR DESCRIPTION
API changed a bit in 1.2.0.rc1, guess it was a leftover.

Clarification: declaring block validator with any options triggered error similar to:

```
`validates_with_block': undefined method `pop' for {:unless=>:planned}:Hash (NoMethodError)
```
