### PR TITLE
on method should return empty array if there are no errors

### DIFF
--- a/lib/dm-validations/validation_errors.rb
+++ b/lib/dm-validations/validation_errors.rb
@@ -99,7 +99,7 @@ module DataMapper
       #   on given field
       def on(field_name)
         errors_for_field = errors[field_name]
-        DataMapper::Ext.blank?(errors_for_field) ? nil : errors_for_field.uniq
+        DataMapper::Ext.blank?(errors_for_field) ? [] : errors_for_field.uniq
       end
 
       def each


### PR DESCRIPTION
Make on method actually return empty array in case of no errors, instead of nil. Method now matches documentation.
