### PR TITLE
Fix/add method validator violation type

### DIFF
--- a/lib/data_mapper/validation/rule/method.rb
+++ b/lib/data_mapper/validation/rule/method.rb
@@ -17,7 +17,8 @@ module DataMapper
         def initialize(attribute_name, options={})
           super
 
-          @method = options.fetch(:method, attribute_name)
+          @method          = options.fetch(:method, attribute_name)
+          @violation_type  = options.fetch(:violation_type, :unsatisfied_condition)
         end
 
         def validate(resource)
@@ -28,6 +29,10 @@ module DataMapper
           else
             Violation.new(resource, error_message, self)
           end
+        end
+
+        def violation_type(resource)
+          @violation_type
         end
 
       end # class Method

--- a/spec/fixtures/programming_language.rb
+++ b/spec/fixtures/programming_language.rb
@@ -32,7 +32,7 @@ module DataMapper
         validates_with_method :ensure_appropriate_for_system_programming,  :when => [:doing_system_programming, :hacking_on_the_kernel, :implementing_a_game_engine]
         validates_with_method :ensure_appropriate_for_dsls,                :when => [:implementing_a_dsl]
         validates_with_method :ensure_appropriate_for_cpu_intensive_tasks, :when => [:implementing_a_game_engine_core]
-        validates_with_method :ensure_approved_by_linus_himself,           :when => [:hacking_on_the_kernel]
+        validates_with_method :ensure_approved_by_linus_himself,           :when => [:hacking_on_the_kernel], :violation_type => :unapproved_by_linus
 
         #
         # API

--- a/spec/integration/method_validator/method_validator_spec.rb
+++ b/spec/integration/method_validator/method_validator_spec.rb
@@ -23,6 +23,10 @@ describe 'a poor candidate for DSLs', :shared => true do
   it 'has a (more or less) meaningful error message' do
     @model.errors.on(:ensure_appropriate_for_dsls).should == [ 'may not be so good for domain specific languages' ]
   end
+
+  it 'has a violation type' do
+    @model.errors[:ensure_appropriate_for_dsls].map(&:type).should == [:unsatisfied_condition]
+  end
 end
 
 
@@ -119,6 +123,7 @@ describe 'C++' do
   it 'is not approved by Linus' do
     @model.valid?(:hacking_on_the_kernel)
     @model.errors.on(:ensure_approved_by_linus_himself).should_not be_empty
+    @model.errors[:ensure_approved_by_linus_himself].map(&:type).should == [:unapproved_by_linus]
   end
 end
 


### PR DESCRIPTION
@emmanuel Maybe we should add a general violation_type(resource) to DataMapper::Violation::Rule instead of merging this pull request? The implementation could be the same. Making this pull request to get the discussion started.
