### PR TITLE
Issue 174 release 1.2 dm-core

### DIFF
--- a/lib/dm-validations/validation_errors.rb
+++ b/lib/dm-validations/validation_errors.rb
@@ -46,7 +46,7 @@ module DataMapper
 
       def initialize(resource)
         @resource = resource
-        @errors   = DataMapper::Validations::OrderedHash.new { |h,k| h[k] = [] }
+        @errors   = DataMapper::Validations::OrderedHash.new 
       end
 
       # Clear existing validation errors.
@@ -123,6 +123,8 @@ module DataMapper
       def [](property_name)
         if (property_errors = errors[property_name.to_sym])
           property_errors
+        else
+          []
         end
       end
 

--- a/lib/dm-validations/validators/block_validator.rb
+++ b/lib/dm-validations/validators/block_validator.rb
@@ -50,7 +50,7 @@ module DataMapper
         method_name = "__validates_with_block_#{@__validates_with_block_count}".to_sym
         define_method(method_name, &block)
 
-        options = fields.last.is_a?(Hash) ? fields.last.pop.dup : {}
+        options = fields.last.is_a?(Hash) ? fields.pop.dup : {}
         options[:method] = method_name
         fields = [method_name] if fields.empty?
 

--- a/spec/fixtures/g3_concert.rb
+++ b/spec/fixtures/g3_concert.rb
@@ -14,13 +14,13 @@ module DataMapper
         # Attributes
         #
 
-        attr_accessor :year, :participants, :city
+        attr_accessor :year, :participants, :city, :planned
 
         #
         # Validations
         #
 
-        validates_with_block :participants do
+        validates_with_block :participants, :unless => :planned do
           if self.class.known_performances.any? { |perf| perf == self }
             true
           else

--- a/spec/integration/block_validator/block_validator_spec.rb
+++ b/spec/integration/block_validator/block_validator_spec.rb
@@ -29,4 +29,13 @@ describe 'DataMapper::Validations::Fixtures::G3Concert' do
 
     it_should_behave_like "valid model"
   end
+
+  describe "planned concert for non-existing year/participants/city combinations" do
+    before :all do
+      @model.planned = true
+      @model.year         = 2021
+    end
+
+    it_should_behave_like "valid model"
+  end
 end

--- a/spec/public/resource_spec.rb
+++ b/spec/public/resource_spec.rb
@@ -102,4 +102,19 @@ describe 'DataMapper::Resource' do
       end
     end
   end
+
+  describe 'Marshal' do
+    before :all do
+      @resource.save
+    end
+
+    describe 'Marshal.load(Marshal.dump(resource))' do
+      it 'should not raise an error' do
+        Marshal.load(Marshal.dump(@resource)).should == @resource 
+      end
+    end
+  end
 end
+
+
+


### PR DESCRIPTION
Good morning. This is a fix for release 1.2 for dm-core issue #174 https://github.com/datamapper/dm-core/issues/174

According to old Lighthouse bugs and such, the issue has been resolved in dm-core a while back. But it seems, if you require dm-validations (or require 'data_mapper' since it does this by proxy), then things go bad again. This is because there are several places within dm-validations where a default value is generated by a proc supplied to the Hash constructor. Marshal.dump/load doesn't deal well with procs for default values. This should all be resolved in the 1.2 line.

I'm working on a fix for the master branch, but it seems this pattern of using procs for hash defaults has propagated, and there is much more to muck with for the master branch.

Lance
