### PR TITLE
Reduce the chance of a rounding error when converting Float to BigDecimal.

### DIFF
--- a/lib/data_mapper/validation/rule/numericalness.rb
+++ b/lib/data_mapper/validation/rule/numericalness.rb
@@ -68,7 +68,7 @@ module DataMapper
         def value_as_string(value)
           case value
           # Avoid Scientific Notation in Float to_s
-          when Float      then value.to_d.to_s('F')
+          when Float      then value.to_d(options.fetch(:precision, nil)).to_s('F')
           when BigDecimal then value.to_s('F')
           else value.to_s
           end


### PR DESCRIPTION
On Ruby 1.9.3 on OS X Lion, doing 67.15.to_d.to_s('F') will return 67.15000000000001.  By passing the precision to to_d it will avoid the likelihood of a slight rounding error.
