### PR TITLE
Uniqueness check should only be skipped if the field is blank

### DIFF
--- a/lib/dm-validations/validators/uniqueness_validator.rb
+++ b/lib/dm-validations/validators/uniqueness_validator.rb
@@ -27,7 +27,7 @@ module DataMapper
 
       def valid?(target)
         value = target.validation_property_value(field_name)
-        return true if optional?(value)
+        return true if optional?(value) && DataMapper::Ext.blank?(value)
 
         opts = {
           :fields    => target.model.key(target.repository.name),

--- a/spec/fixtures/corporate_world.rb
+++ b/spec/fixtures/corporate_world.rb
@@ -34,6 +34,20 @@ module DataMapper
         validates_uniqueness_of :user_name, :when => :signing_up_for_department_account,   :scope => [:department]
         validates_uniqueness_of :user_name, :when => :signing_up_for_organization_account, :scope => [:organisation]
       end
+
+      class Manager
+        include DataMapper::Resource
+
+        property :id, Serial
+        property :name, String
+        property :title, String
+
+        validates_uniqueness_of :title, :if => :has_title?
+
+        def has_title?
+          !title.nil? && title != ''
+        end
+      end
     end
   end
 end

--- a/spec/integration/uniqueness_validator/uniqueness_validator_spec.rb
+++ b/spec/integration/uniqueness_validator/uniqueness_validator_spec.rb
@@ -113,4 +113,35 @@ describe 'uniqueness_validator/uniqueness_validator_spec' do
     end
   end
 
+  describe 'DataMapper::Validations::Fixtures::Manager' do
+    before :all do
+      DataMapper::Validations::Fixtures::Manager.destroy!
+
+      DataMapper::Validations::Fixtures::Manager.create(:name => "John", :title => 'CEO').should be_saved
+    end
+
+    describe "with unique title" do
+      before do
+        @model = DataMapper::Validations::Fixtures::Manager.new(:name => 'Bob', :title => 'COO')
+      end
+
+      it_should_behave_like "valid model"
+    end
+
+    describe "with a duplicate title" do
+      before do
+        @model = DataMapper::Validations::Fixtures::Manager.new(:name => 'Bob', :title => 'CEO')
+      end
+
+      it_should_behave_like "invalid model"
+    end
+
+    describe "with no title" do
+      before do
+        @model = DataMapper::Validations::Fixtures::Manager.new(:name => 'Bob')
+      end
+
+      it_should_behave_like "valid model"
+    end
+  end
 end


### PR DESCRIPTION
Default behaviour for the uniqueness validator is to skip over a field if it is allowed to be blank or nil.  It _should_ only skip those fields if they are also set to blank, otherwise uniqueness errors can occur.  Attached is a fix and an updated spec.
