### PR TITLE
Fix uniqueness validation to correctly work with STI

### DIFF
--- a/lib/dm-validations/validators/uniqueness_validator.rb
+++ b/lib/dm-validations/validators/uniqueness_validator.rb
@@ -42,8 +42,9 @@ module DataMapper
           opts[subject] = target.__send__(subject)
         }
 
+        property = target.model.properties[field_name]
         resource = DataMapper.repository(target.repository.name) do
-          target.model.first(opts)
+          property.model.first(opts)
         end
 
         return true if resource.nil?

--- a/spec/fixtures/corporate_world.rb
+++ b/spec/fixtures/corporate_world.rb
@@ -18,6 +18,7 @@ module DataMapper
 
         property :id, Serial
         property :name, String, :unique_index => true
+        property :type, Discriminator
 
         validates_uniqueness_of :name
       end
@@ -34,6 +35,9 @@ module DataMapper
         validates_uniqueness_of :user_name, :when => :signing_up_for_department_account,   :scope => [:department]
         validates_uniqueness_of :user_name, :when => :signing_up_for_organization_account, :scope => [:organisation]
       end
+
+      # For STI uniqueness testing
+      class BigDepartment < Department; end
     end
   end
 end

--- a/spec/integration/uniqueness_validator/uniqueness_validator_spec.rb
+++ b/spec/integration/uniqueness_validator/uniqueness_validator_spec.rb
@@ -26,6 +26,14 @@ describe 'uniqueness_validator/uniqueness_validator_spec' do
 
       it_should_behave_like "invalid model"
     end
+
+    describe "with duplicate name in a child class" do
+      before do
+        @model = DataMapper::Validations::Fixtures::BigDepartment.new(:name => "HR")
+      end
+
+      it_should_behave_like "invalid model"
+    end
   end
 
   describe 'DataMapper::Validations::Fixtures::Organisation' do


### PR DESCRIPTION
Currently, uniqueness validation check is done by calling `resource.model.first`, which only scopes the query to that particular class.  This patch uses `property.model` instead to scope the query to the class in which the property was defined and its children.

This is the best solution that I could find.  There is no easy way to scope the query to the class which calls `validates_uniqueness_of`, only the class that defines the property.
