### PR TITLE
[master] Use a more RFC2396 complaint regex pattern for the :url format validation

### DIFF
--- a/lib/data_mapper/validation/rule/formats/url.rb
+++ b/lib/data_mapper/validation/rule/formats/url.rb
@@ -1,13 +1,14 @@
 # encoding: utf-8
 
+require 'uri'
+
 module DataMapper
   module Validation
     class Rule
       module Formats
 
-        # Regex from http://www.igvita.com/2006/09/07/validating-url-in-ruby-on-rails/
         Url = begin
-          /(^$)|(^(http|https):\/\/[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}((\:[0-9]{1,5})?\/?.*)?$)/ix
+          URI.regexp(['http','https'])
         end
 
       end # module Formats


### PR DESCRIPTION
The current format's url regular expression pattern was tripping on a number of valid URLs, so this change updates it to use `URI.regexp`, which is provided by the ruby stdlib. To maintain some compatibility with the old regex, I have limited the valid urls accepted by this regex to only the `http` and `https` schemes, which may or may not be desired.
