### PR TITLE
[release-1.2] Use a more RFC2396 complaint regex pattern for the :url format validation

### DIFF
--- a/lib/dm-validations/formats/url.rb
+++ b/lib/dm-validations/formats/url.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require 'uri'
+
 module DataMapper
   module Validations
     module Format
@@ -17,8 +19,7 @@ module DataMapper
         end
 
         Url = begin
-          # Regex from http://www.igvita.com/2006/09/07/validating-url-in-ruby-on-rails/
-          /(^$)|(^(http|https):\/\/[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}((\:[0-9]{1,5})?\/?.*)?$)/ix
+          URI.regexp(['http','https'])
         end
 
       end # module Url


### PR DESCRIPTION
The current format's url regular expression pattern was tripping on a number of valid URLs, so this change updates it to use `URI.regexp`, which is provided by the ruby stdlib. To maintain some compatibility with the old regex, I have limited the valid urls accepted by this regex to only the `http` and `https` schemes, which may or may not be desired.
