### PR TITLE
Do not call validators if model is not dirty

### DIFF
--- a/lib/dm-validations.rb
+++ b/lib/dm-validations.rb
@@ -48,6 +48,7 @@ module DataMapper
 
     # @api private
     def save_self(*)
+      return super unless dirty_self?
       if Validations::Context.any? && !valid?(model.validators.current_context)
         false
       else

--- a/lib/dm-validations.rb
+++ b/lib/dm-validations.rb
@@ -48,7 +48,7 @@ module DataMapper
 
     # @api private
     def save_self(*)
-      return super unless dirty_self?
+      return super unless dirty_self? || new?
       if Validations::Context.any? && !valid?(model.validators.current_context)
         false
       else


### PR DESCRIPTION
There is no need to call validators (specially those which need to hit the database like :unique) if the model is not dirty.
This has special incidence, when a model has many parents with unique properties, in which the current version will call all validators for all parent models despite the fact that they don't need saving