### PR TITLE
Fix error in email validation

### DIFF
--- a/lib/data_mapper/validation/rule/formats/email.rb
+++ b/lib/data_mapper/validation/rule/formats/email.rb
@@ -27,7 +27,7 @@ module DataMapper
           end
           digit          = '0-9'
           atext          = "[#{letter}#{digit}\!\#\$\%\&\'\*+\/\=\?\^\_\`\{\|\}\~\-]"
-          dot_atom_text  = "#{atext}+([.]#{atext}*)+"
+          dot_atom_text  = "#{atext}+([.]#{atext}+)+"
           dot_atom       = dot_atom_text
           no_ws_ctl      = '\x01-\x08\x11\x12\x14-\x1f\x7f'
           qtext          = "[^#{no_ws_ctl}\\x0d\\x22\\x5c]"  # Non-whitespace, non-control character except for \ and "

--- a/spec/integration/format_validator/email_format_validator_spec.rb
+++ b/spec/integration/format_validator/email_format_validator_spec.rb
@@ -42,7 +42,12 @@ describe 'DataMapper::Validations::Fixtures::BillOfLading' do
         'Job@Book of Job',
         'test@localhost',
         'J. P. \'s-Gravezande, a.k.a. The Hacker!@example.com',
-        "test@example.com\nsomething after the newline"].each do |email|
+        "test@example.com\nsomething after the newline",
+        'mal.@example.com',
+        'mal.formed.@example.com',
+        'mal.formed@example.',
+        'mal.formed@example.com.',
+        'mal.formed@example...com'].each do |email|
     describe "with email value of #{email} (non RFC2822 compliant)" do
       before :all do
         @model = DataMapper::Validations::Fixtures::BillOfLading.new(valid_attributes.merge(:email => email))


### PR DESCRIPTION
Fix so that email validation no longer accepts addresses such as "mal.formed@example...com" or "mal.formed.@example." The fix is to require at least one atext following a dot. 

From http://www.ietf.org/rfc/rfc2822.txt:
`dot-atom-text   =       1*atext *("." 1*atext)`
where "1*" means "at least 1"
