### PR TITLE
Revert change to private for inherited to prevent change to resource 

### DIFF
--- a/lib/data_mapper/validation.rb
+++ b/lib/data_mapper/validation.rb
@@ -93,8 +93,6 @@ module DataMapper
         @validation_rules ||= ContextualRuleSet.new(self)
       end
 
-    private
-
       # @api private
       def inherited(base)
         super


### PR DESCRIPTION
`inherited` being made public by dm

This change https://github.com/datamapper/dm-validations/commit/145100db6dc6e9f6baab9cb63ba5bedd31e27ea1#diff-3fa714c2908862ba7f6e400ced298674

Causes this issue in dm-is-list https://github.com/datamapper/dm-is-list/issues/6

Which lead to this attempted change in dm-core: https://github.com/datamapper/dm-core/issues/277

And subsequent discussion lead to making this script: https://gist.github.com/tpitale/b67e1f86763ba6ea0b75

To find that dm-validations was switching `inherited` from public back to private.